### PR TITLE
[WIP] Use SQLite

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,6 @@ pkg
 .env
 docker.env
 dist
+
+# SQLite
+sqlite.db

--- a/database/Cargo.toml
+++ b/database/Cargo.toml
@@ -6,6 +6,6 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-sea-orm = { version = "0.10.1", features = ["sqlx-postgres", "runtime-actix-rustls", "macros"]}
+sea-orm = { version = "0.10.1", features = ["sqlx-sqlite", "runtime-actix-rustls", "macros"]}
 migration = { path = "./migration"}
 entity = { path = "./entity"}

--- a/database/migration/Cargo.toml
+++ b/database/migration/Cargo.toml
@@ -10,6 +10,7 @@ path = "src/lib.rs"
 
 [dependencies]
 async-std = { version = "^1", features = ["attributes", "tokio1"] }
+chrono = "0.4.23"
 entity = { path = "../entity" }
 shared = { path = "../../shared" }
 
@@ -17,5 +18,5 @@ shared = { path = "../../shared" }
 version = "^0.10.0"
 features = [
   "runtime-actix-rustls",
-  "sqlx-postgres"
+  "sqlx-sqlite"
 ]

--- a/database/migration/src/m20221106_104329_create_review_table.rs
+++ b/database/migration/src/m20221106_104329_create_review_table.rs
@@ -23,12 +23,7 @@ impl MigrationTrait for Migration {
                     .col(ColumnDef::new(Review::ReviewerName).string().not_null())
                     .col(ColumnDef::new(Review::ReviewText).string().not_null())
                     .col(ColumnDef::new(Review::Rating).integer().not_null())
-                    .col(
-                        ColumnDef::new(Review::Date)
-                            .timestamp()
-                            .default("now()")
-                            .not_null(),
-                    )
+                    .col(ColumnDef::new(Review::Date).timestamp().not_null())
                     .col(ColumnDef::new(Review::BeerId).integer().not_null())
                     .foreign_key(
                         ForeignKey::create()

--- a/database/migration/src/m20221106_115011_db_seeder.rs
+++ b/database/migration/src/m20221106_115011_db_seeder.rs
@@ -1,3 +1,4 @@
+use chrono;
 use sea_orm_migration::prelude::*;
 use sea_orm_migration::sea_orm::prelude::Decimal;
 use sea_orm_migration::sea_orm::{ActiveModelTrait, EntityTrait, Set};
@@ -27,6 +28,7 @@ impl MigrationTrait for Migration {
         entity::review::ActiveModel {
             reviewer_name: Set("therock2011(333)".to_owned()),
             rating: Set(3),
+            date: Set(chrono::offset::Local::now().naive_local()),
             review_text: Set("Golden colour has a citrus smell anice citrus flavour with a nice happy citrus kick".to_owned()),
             beer_id: Set(stone.id as i32),
             ..Default::default()
@@ -37,6 +39,7 @@ impl MigrationTrait for Migration {
         entity::review::ActiveModel {
             reviewer_name: Set("p0rkch0p".to_owned()),
             rating: Set(4),
+            date: Set(chrono::offset::Local::now().naive_local()),
             review_text: Set("Pour from can is dark plum with faint frothy purple foam head. Probably not consumed at a cool enough temperature  but tastes just fine at room temp. Obviously berry sweet but not too much. Great carbonation with lively fizzy sound. Labeled as IPA but you wouldnt know unless they told you. Not a session beer but perfect for pairing with a meal or post meal.".to_owned()),
             beer_id: Set(stone.id as i32),
             ..Default::default()

--- a/shared/src/lib.rs
+++ b/shared/src/lib.rs
@@ -5,7 +5,7 @@ pub const FRONTEND_HOST_KEY: &str = "FRONTEND_HOST";
 pub const FRONTEND_PORT_KEY: &str = "FRONTEND_PORT";
 pub const FRONTEND_PROTOCOL_KEY: &str = "FRONTEND_PROTOCOL";
 
-pub const DEFAULT_DB_URL: &str = "postgres://localhost:5432/";
+pub const DEFAULT_DB_URL: &str = "sqlite:./sqlite.db?mode=rwc";
 pub const DATABASE_URL_KEY: &str = "DATABASE_URL";
 pub const DATABASE_PROTOCOL_KEY: &str = "DATABASE_PROTOCOL";
 pub const DATABASE_PORT_KEY: &str = "DATABASE_PORT";


### PR DESCRIPTION
The benefit of SQLite is that it's embedded, so the backend no longer needs a DB server to be running.

Probably needs more changes in the backend, because inserting reviews requires the `date` field.
The reason for that is: SQLite doesn't have the `now()` function, it wants `date('now')`, however, `sea-orm` refuses to parse that as a valid date...